### PR TITLE
Some corrections and suggestions for the Dutch translations

### DIFF
--- a/dicts/translations-basic-dictionary-dutch.trsl
+++ b/dicts/translations-basic-dictionary-dutch.trsl
@@ -60,9 +60,9 @@
 \ProvideDictTranslation{Index}{Register}
 \ProvideDictTranslation{Introduction}{Inleiding}
 \ProvideDictTranslation{introduction}{inleiding}
-\ProvideDictTranslation{List of Figures and Tables}{L\ij st van figuren en tabellen}
-\ProvideDictTranslation{List of Figures}{L\ij st van figuren}
-\ProvideDictTranslation{List of Tables}{L\ij st van tabellen}
+\ProvideDictTranslation{List of Figures and Tables}{Figuren- en Tabellen\-l\ij st}
+\ProvideDictTranslation{List of Figures}{Figuren\-l\ij st}
+\ProvideDictTranslation{List of Tables}{Tabellen\-l\ij st}
 \ProvideDictTranslation{or}{of}
 \ProvideDictTranslation{Outline}{Indeling}
 \ProvideDictTranslation{Overview}{Overzicht}
@@ -78,7 +78,7 @@
 \ProvideDictTranslation{parts}{delen}
 \ProvideDictTranslation{Part}{Deel}
 \ProvideDictTranslation{part}{deel}
-\ProvideDictTranslation{Preface}{Woord vooraf}
+\ProvideDictTranslation{Preface}{Voorwoord}
 \ProvideDictTranslation{Proofs}{Bew\ij zen}
 \ProvideDictTranslation{proofs}{Bew\ij zen}
 \ProvideDictTranslation{Proof}{Bew\ij s}
@@ -94,10 +94,10 @@
 \ProvideDictTranslation{see also}{zie ook}
 \ProvideDictTranslation{See}{Zie}
 \ProvideDictTranslation{see}{zie}
-\ProvideDictTranslation{Sketch of Proofs}{Bew\ij sschetsen}
-\ProvideDictTranslation{Sketch of proofs}{bew\ij sschetsen}
-\ProvideDictTranslation{Sketch of Proof}{Bew\ij sschets}
-\ProvideDictTranslation{Sketch of proof}{bew\ij sschets}
+\ProvideDictTranslation{Sketch of Proofs}{Bew\ij s\-schetsen}
+\ProvideDictTranslation{Sketch of proofs}{bew\ij s\-schetsen}
+\ProvideDictTranslation{Sketch of Proof}{Bew\ij s\-schets}
+\ProvideDictTranslation{Sketch of proof}{bew\ij s\-schets}
 \ProvideDictTranslation{Subsections}{Subparagrafen}
 \ProvideDictTranslation{subsections}{subparagrafen}
 \ProvideDictTranslation{Subsection}{Subparagraaf}

--- a/dicts/translations-basic-dictionary-dutch.trsl
+++ b/dicts/translations-basic-dictionary-dutch.trsl
@@ -110,24 +110,24 @@
 \ProvideDictTranslation{To}{Aan}
 \ProvideDictTranslation{to}{aan}
 
-\ProvideDictTranslation{Monday}{Maandag}
-\ProvideDictTranslation{Tuesday}{Dinsdag}
-\ProvideDictTranslation{Wednesday}{Woensdag}
-\ProvideDictTranslation{Thursday}{Donderdag}
-\ProvideDictTranslation{Friday}{Vr\ij dag}
-\ProvideDictTranslation{Saturday}{Zaterdag}
-\ProvideDictTranslation{Sunday}{Zondag}
+\ProvideDictTranslation{Monday}{maandag}
+\ProvideDictTranslation{Tuesday}{dinsdag}
+\ProvideDictTranslation{Wednesday}{woensdag}
+\ProvideDictTranslation{Thursday}{donderdag}
+\ProvideDictTranslation{Friday}{vr\ij dag}
+\ProvideDictTranslation{Saturday}{zaterdag}
+\ProvideDictTranslation{Sunday}{zondag}
 
-\ProvideDictTranslation{January}{Januari}
-\ProvideDictTranslation{February}{Februari}
-\ProvideDictTranslation{March}{Maart}
-\ProvideDictTranslation{April}{April}
-\ProvideDictTranslation{May}{Mei}
-\ProvideDictTranslation{June}{Juni}
-\ProvideDictTranslation{July}{Juli}
-\ProvideDictTranslation{August}{Augustus}
-\ProvideDictTranslation{September}{September}
-\ProvideDictTranslation{October}{Oktober}
-\ProvideDictTranslation{November}{November}
-\ProvideDictTranslation{December}{December}
+\ProvideDictTranslation{January}{januari}
+\ProvideDictTranslation{February}{februari}
+\ProvideDictTranslation{March}{maart}
+\ProvideDictTranslation{April}{april}
+\ProvideDictTranslation{May}{mei}
+\ProvideDictTranslation{June}{juni}
+\ProvideDictTranslation{July}{juli}
+\ProvideDictTranslation{August}{augustus}
+\ProvideDictTranslation{September}{september}
+\ProvideDictTranslation{October}{oktober}
+\ProvideDictTranslation{November}{november}
+\ProvideDictTranslation{December}{december}
 


### PR DESCRIPTION
Hi,

Here, I have two commits for the Dutch translations:
- One is to fix the capitalization of weekday and month names (originally they were capitalized, but they should not be);
- Another one contains some stylistic improvements, however these are more subjective.

Thanks!

Regards,

Luuk